### PR TITLE
ajout du support pour ForumJV

### DIFF
--- a/respawnIrc/accountListWindow.cpp
+++ b/respawnIrc/accountListWindow.cpp
@@ -111,7 +111,10 @@ void accountListWindowClass::connectWithThisAccount()
 {
     if(viewListOfAccount.currentIndex().row() != -1)
     {
-        emit useThisAccount(listOfAccount->at(viewListOfAccount.currentIndex().row()).listOfCookie, listOfAccount->at(viewListOfAccount.currentIndex().row()).pseudo, false, rememberBox.isChecked());
+        QString pseudo = listOfAccount->at(viewListOfAccount.currentIndex().row()).pseudo;
+        pseudo.remove(pseudo.indexOf(' '), pseudo.size() - pseudo.indexOf(' '));
+
+        emit useThisAccount(listOfAccount->at(viewListOfAccount.currentIndex().row()).listOfCookie, pseudo, false, rememberBox.isChecked());
         close();
     }
 }
@@ -120,6 +123,9 @@ void accountListWindowClass::connectToOneTopicWithThisAccount()
 {
     if(viewListOfAccount.currentIndex().row() != -1)
     {
+        QString pseudo = listOfAccount->at(viewListOfAccount.currentIndex().row()).pseudo;
+        pseudo.remove(pseudo.indexOf(' '), pseudo.size() - pseudo.indexOf(' '));
+
         emit useThisAccountForOneTopic(listOfAccount->at(viewListOfAccount.currentIndex().row()).listOfCookie, listOfAccount->at(viewListOfAccount.currentIndex().row()).pseudo, rememberBox.isChecked());
         close();
     }

--- a/respawnIrc/connectWindow.cpp
+++ b/respawnIrc/connectWindow.cpp
@@ -15,7 +15,8 @@ connectWindowClass::connectWindowClass(QWidget* parent, bool showRemeberBox) : Q
 
     QLabel* labForPseudo = new QLabel("Entrez le pseudo avec lequel vous voulez vous connecter :", this);
     QLabel* labForButton = new QLabel("Une fois connecté, cliquez ici :", this);
-    buttonShowWebView = new QPushButton("Afficher la page de connexion", this);
+    buttonShowJVCWebView = new QPushButton("Login with jeuxvideo.com", this);
+    buttonShowForumJVWebView = new QPushButton("Login with forumjv.com", this);
     QPushButton* buttonAddCookies = new QPushButton("Ajouter des cookies", this);
     QPushButton* buttonValidate = new QPushButton("Valider", this);
     QPushButton* buttonHelp = new QPushButton("Aide pour se connecter", this);
@@ -31,7 +32,8 @@ connectWindowClass::connectWindowClass(QWidget* parent, bool showRemeberBox) : Q
     bottomLayout->addWidget(buttonValidate);
 
     mainLayout = new QVBoxLayout(this);
-    mainLayout->addWidget(buttonShowWebView);
+    mainLayout->addWidget(buttonShowJVCWebView);
+    mainLayout->addWidget(buttonShowForumJVWebView);
     mainLayout->addLayout(bottomLayout);
 
     if(showRemeberBox == true)
@@ -52,27 +54,47 @@ connectWindowClass::connectWindowClass(QWidget* parent, bool showRemeberBox) : Q
     setLayout(mainLayout);
     setWindowTitle("Page de connexion");
 
-    connect(buttonShowWebView, &QPushButton::clicked, this, &connectWindowClass::addWebView);
+    connect(buttonShowJVCWebView, &QPushButton::pressed, this, &connectWindowClass::addWebViewJVC);
+    connect(buttonShowForumJVWebView, &QPushButton::pressed, this, &connectWindowClass::addWebViewForumJV);
     connect(buttonAddCookies, &QPushButton::clicked, this, &connectWindowClass::showAddCookiesWindow);
     connect(buttonValidate, &QPushButton::clicked, this, &connectWindowClass::valideConnect);
     connect(buttonHelp, &QPushButton::clicked, this, &connectWindowClass::showHelpConnect);
 }
 
-void connectWindowClass::addWebView()
+void connectWindowClass::addWebViewJVC()
 {
     if(webView == nullptr)
     {
-        QWebEngineProfile* customProfile = new QWebEngineProfile(this);
-        QWebEnginePage* customPage = new QWebEnginePage(customProfile, this);
-
         webView = new QWebEngineView(this);
 
-        webView->setPage(customPage);
+        webView->page()->profile()->cookieStore()->deleteAllCookies();
+        webView->page()->profile()->setPersistentCookiesPolicy(QWebEngineProfile::NoPersistentCookies);
         webView->load(QUrl("http://www.jeuxvideo.com/login"));
+        website = "JeuxVideo.com";
 
-        mainLayout->removeWidget(buttonShowWebView);
-        buttonShowWebView->setEnabled(false);
-        buttonShowWebView->setVisible(false);
+        mainLayout->removeWidget(buttonShowJVCWebView);
+        buttonShowJVCWebView->setEnabled(false);
+        buttonShowJVCWebView->setVisible(false);
+        mainLayout->insertWidget(0, webView);
+
+        connect(webView->page()->profile()->cookieStore(), &QWebEngineCookieStore::cookieAdded, this, &connectWindowClass::checkThisCookie);
+    }
+}
+
+void connectWindowClass::addWebViewForumJV()
+{
+    if(webView == nullptr)
+    {
+        webView = new QWebEngineView(this);
+
+        webView->page()->profile()->cookieStore()->deleteAllCookies();
+        webView->page()->profile()->setPersistentCookiesPolicy(QWebEngineProfile::NoPersistentCookies);
+        webView->load(QUrl("http://www.forumjv.com/login"));
+        website = "ForumJV";
+
+        mainLayout->removeWidget(buttonShowForumJVWebView);
+        buttonShowForumJVWebView->setEnabled(false);
+        buttonShowForumJVWebView->setVisible(false);
         mainLayout->insertWidget(0, webView);
 
         connect(webView->page()->profile()->cookieStore(), &QWebEngineCookieStore::cookieAdded, this, &connectWindowClass::checkThisCookie);
@@ -116,7 +138,9 @@ void connectWindowClass::valideConnect()
 {
     if(pseudoLine.text().isEmpty() == false && cookieList.size() >= 2)
     {
-        emit newCookiesAvailable(cookieList, pseudoLine.text(), rememberBox.isChecked(), rememberBox.isChecked());
+        QString pseudo = pseudoLine.text() + " ("+website+")";
+
+        emit newCookiesAvailable(cookieList, pseudo, rememberBox.isChecked(), rememberBox.isChecked());
         close();
         return;
     }

--- a/respawnIrc/connectWindow.hpp
+++ b/respawnIrc/connectWindow.hpp
@@ -18,7 +18,8 @@ class connectWindowClass : public QDialog
 public:
     explicit connectWindowClass(QWidget* parent, bool showRemeberBox = true);
 public slots:
-    void addWebView();
+    void addWebViewJVC();
+    void addWebViewForumJV();
     void checkThisCookie(QNetworkCookie cookie);
     void showAddCookiesWindow();
     void addCookiesManually(QString newHelloCookie, QString newConnectCookie);
@@ -29,7 +30,9 @@ signals:
 private:
     QList<QNetworkCookie> cookieList;
     QWebEngineView* webView = nullptr;
-    QPushButton* buttonShowWebView;
+    QPushButton* buttonShowJVCWebView;
+    QPushButton* buttonShowForumJVWebView;
+    QString website;
     QVBoxLayout* mainLayout;
     QLineEdit pseudoLine;
     QCheckBox rememberBox;

--- a/respawnIrc/getTopicMessages.cpp
+++ b/respawnIrc/getTopicMessages.cpp
@@ -17,8 +17,9 @@ getTopicMessagesClass::getTopicMessagesClass(QObject* parent) : QObject(parent)
     connect(timerForGetMessage, &QTimer::timeout, this, &getTopicMessagesClass::getMessages);
 }
 
-void getTopicMessagesClass::setNewTopic(QString newTopicLink, bool getFirstMessage)
+void getTopicMessagesClass::setNewTopic(QString newTopicLink, bool getFirstMessage, QString website)
 {
+    mWebsite = website;
     needToGetFirstMessage = getFirstMessage;
     listOfEdit.clear();
     linkHasChanged = true;
@@ -67,7 +68,7 @@ void getTopicMessagesClass::setNewCookies(QList<QNetworkCookie> newCookies, QStr
         {
             networkManager->clearAccessCache();
             networkManager->setCookieJar(new QNetworkCookieJar(this));
-            networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://www.jeuxvideo.com"));
+            networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://"+mWebsite));
 
             if(updateMessages == true)
             {
@@ -291,7 +292,7 @@ void getTopicMessagesClass::analyzeMessages()
     {
         if(locationHeader.startsWith("/forums/") == true)
         {
-            topicLink = "http://www.jeuxvideo.com" + locationHeader;
+            topicLink = "hhttp://"+mWebsite + locationHeader;
             emit newLinkForTopic(topicLink);
             retrievesMessage = false;
             startGetMessage();
@@ -315,7 +316,7 @@ void getTopicMessagesClass::analyzeMessages()
         emit newNumberOfConnectedAndMP(parsingToolClass::getNumberOfConnected(listOfPageSource[firstValidePageNumber]), "", false);
     }
 
-    newTopicLink = parsingToolClass::getLastPageOfTopic(listOfPageSource[firstValidePageNumber]);
+    newTopicLink = parsingToolClass::getLastPageOfTopic(listOfPageSource[firstValidePageNumber], mWebsite);
 
     if(newTopicLink.isEmpty() == true && topicLink != listOfPageUrl[firstValidePageNumber])
     {

--- a/respawnIrc/getTopicMessages.hpp
+++ b/respawnIrc/getTopicMessages.hpp
@@ -33,7 +33,7 @@ class getTopicMessagesClass : public QObject
 public:
     explicit getTopicMessagesClass(QObject* parent = 0);
 public slots:
-    void setNewTopic(QString newTopicLink, bool getFirstMessage);
+    void setNewTopic(QString newTopicLink, bool getFirstMessage, QString website);
     void setNewCookies(QList<QNetworkCookie> newCookies, QString newPseudoOfUser, bool updateMessages);
     void settingsChanged(settingsForMessageParsingStruct newSettings);
     void startGetMessage();
@@ -58,6 +58,7 @@ private:
     QMap<long, QString> listOfEdit;
     QTimer* timerForGetMessage;
     QString topicLink;
+    QString mWebsite;
     QString pseudoOfUser;
     settingsForMessageParsingStruct settingsForMessageParsing;
     bool needToGetFirstMessage;

--- a/respawnIrc/parsingTool.hpp
+++ b/respawnIrc/parsingTool.hpp
@@ -66,20 +66,21 @@ namespace parsingToolClass
     ajaxInfoStruct getAjaxInfo(const QString& source);
     QString getMessageEditAndChangeSource(QString& source); //ici le & est important
     QString getMessageQuote(const QString& source);
+    QString getWebsite(const QString &source);
     QString getVersionName(const QString& source);
     QString getVersionChangelog(const QString& source);
     void getListOfHiddenInputFromThisForm(const QString& source, QString formName, QList<QPair<QString, QString> >& listOfInput);
     bool getTopicLocked(const QString& source);
     QString getCaptchaLink(const QString& source);
     QString getErrorMessage(const QString& source);
-    QString getLastPageOfTopic(const QString& source);
+    QString getLastPageOfTopic(const QString& source, const QString& website);
     QString getFirstPageOfTopic(const QString& source);
     QString getBeforeLastPageOfTopic(const QString& source);
     QString getNameOfTopic(const QString& source);
     QString getNumberOfConnected(const QString& source);
     QString getNumberOfMp(const QString& source);
     QList<messageStruct> getListOfEntireMessagesWithoutMessagePars(const QString& source);
-    QList<topicStruct> getListOfTopic(const QString& source);
+    QList<topicStruct> getListOfTopic(const QString& source, const QString &website);
     QString getForumOfTopic(const QString& source);
     QString getForumName(const QString& source);
     QString jvfLinkToJvcLink(const QString& source);

--- a/respawnIrc/selectTopicWindow.cpp
+++ b/respawnIrc/selectTopicWindow.cpp
@@ -56,10 +56,10 @@ QString selectTopicWindowClass::transformLinkIfNeeded(QString link)
         link.replace("http://jeuxvideo.com/", "http://www.jeuxvideo.com/");
     }
 
-    if(link.startsWith("http://www.jeuxvideo.com/") == false && link.startsWith("http://jvforum.fr/") == false)
-    {
-        return "";
-    }
+  //  if(link.startsWith("http://www.jeuxvideo.com/") == false && link.startsWith("http://jvforum.fr/") == false)
+   // {
+  //      return "";
+  //  }
 
     return link;
 }
@@ -70,14 +70,14 @@ void selectTopicWindowClass::selectThisTopic()
 
     if(newLink.isEmpty() == false)
     {
-        if(newLink.startsWith("http://jvforum.fr/") == true)
-        {
-            emit newTopicSelected(parsingToolClass::jvfLinkToJvcLink(newLink));
-        }
-        else
-        {
-            emit newTopicSelected(newLink);
-        }
+      //  if(newLink.startsWith("http://jvforum.fr/") == true)
+      //  {
+       //     emit newTopicSelected(parsingToolClass::jvfLinkToJvcLink(newLink));
+      // }
+      //  else
+      //  {
+        //    emit newTopicSelected(newLink);
+       // }
         close();
     }
     else

--- a/respawnIrc/sendMessages.cpp
+++ b/respawnIrc/sendMessages.cpp
@@ -172,15 +172,16 @@ void sendMessagesClass::postMessage(QString pseudoUsed, QString topicLink, const
     {
         QNetworkRequest request;
         QString data;
+        QString website = parsingToolClass::getWebsite(topicLink);
 
         cookieListForPostMsg = listOfCookies;
         networkManager->clearAccessCache();
         networkManager->setCookieJar(new QNetworkCookieJar(this));
-        networkManager->cookieJar()->setCookiesFromUrl(cookieListForPostMsg, QUrl("http://www.jeuxvideo.com"));
+        networkManager->cookieJar()->setCookiesFromUrl(cookieListForPostMsg, QUrl("http://"+website));
 
         if(isInEdit == true)
         {
-            request = parsingToolClass::buildRequestWithThisUrl("http://www.jeuxvideo.com/forums/ajax_edit_message.php");
+            request = parsingToolClass::buildRequestWithThisUrl("http://"+website+"/forums/ajax_edit_message.php");
         }
         else
         {

--- a/respawnIrc/showListOfTopic.cpp
+++ b/respawnIrc/showListOfTopic.cpp
@@ -57,6 +57,8 @@ void showListOfTopicClass::setForumLink(QString newForumLink)
     }
 
     forumLink = newForumLink;
+
+    mWebsite = parsingToolClass::getWebsite(newForumLink);
     modelForListView.clear();
     if(newForumLink.isEmpty() == false)
     {
@@ -79,7 +81,7 @@ void showListOfTopicClass::setNewCookies(QList<QNetworkCookie> newCookies)
     {
         networkManager->clearAccessCache();
         networkManager->setCookieJar(new QNetworkCookieJar(this));
-        networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://www.jeuxvideo.com"));
+        networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://"+mWebsite));
     }
 }
 
@@ -177,7 +179,7 @@ void showListOfTopicClass::analyzeReply()
     {
         if(locationHeader.startsWith("/forums/") == true)
         {
-            forumLink = "http://www.jeuxvideo.com" + locationHeader;
+            forumLink = "http://"+mWebsite+ locationHeader;
             reply = nullptr;
             startGetListOfTopic();
             return;
@@ -185,7 +187,7 @@ void showListOfTopicClass::analyzeReply()
     }
     else
     {
-        QList<topicStruct> listOfTopic = parsingToolClass::getListOfTopic(source);
+        QList<topicStruct> listOfTopic = parsingToolClass::getListOfTopic(source, mWebsite);
         QStandardItem* newItemToAppend;
         QFont tmpFont;
 

--- a/respawnIrc/showListOfTopic.hpp
+++ b/respawnIrc/showListOfTopic.hpp
@@ -39,6 +39,7 @@ signals:
 private:
     QTimer timerForGetList;
     QString forumLink;
+    QString mWebsite;
     QListView listViewOfTopic;
     QStandardItemModel modelForListView;
     autoTimeoutReplyClass timeoutForReply;

--- a/respawnIrc/showTopicMessages.cpp
+++ b/respawnIrc/showTopicMessages.cpp
@@ -142,7 +142,7 @@ void showTopicMessagesClass::setNewCookies(QList<QNetworkCookie> newCookies, QSt
     {
         networkManager->clearAccessCache();
         networkManager->setCookieJar(new QNetworkCookieJar(this));
-        networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://www.jeuxvideo.com"));
+        networkManager->cookieJar()->setCookiesFromUrl(newCookies, QUrl("http://"+website));
         currentErrorStreak = 0;
     }
 
@@ -327,6 +327,7 @@ void showTopicMessagesClass::setNewTopic(QString newTopic)
     currentTypeOfEdit = realTypeOfEdit;
     firstMessageOfTopic.isFirstMessage = false;
     topicLinkLastPage = newTopic;
+    website = parsingToolClass::getWebsite(newTopic);
     topicLinkFirstPage = parsingToolClass::getFirstPageOfTopic(newTopic);
     firstTimeGetMessages = true;
     errorMode = false;
@@ -335,7 +336,7 @@ void showTopicMessagesClass::setNewTopic(QString newTopic)
     oldIdOfLastMessageOfUser = 0;
     needToGetMessages = false;
     oldUseMessageEdit = false;
-    QMetaObject::invokeMethod(getTopicMessages, "setNewTopic", Qt::QueuedConnection, Q_ARG(QString, newTopic), Q_ARG(bool, getFirstMessageOfTopic));
+    QMetaObject::invokeMethod(getTopicMessages, "setNewTopic", Qt::QueuedConnection, Q_ARG(QString, newTopic), Q_ARG(bool, getFirstMessageOfTopic), Q_ARG(QString, website));
 }
 
 void showTopicMessagesClass::linkClicked(const QUrl& link)
@@ -392,7 +393,7 @@ bool showTopicMessagesClass::getEditInfo(long idOfMessageToEdit, bool useMessage
                 oldIdOfLastMessageOfUser = idOfMessageToEdit;
             }
 
-            urlToGet = "http://www.jeuxvideo.com/forums/ajax_edit_message.php?id_message=" + QString::number(oldIdOfLastMessageOfUser) + "&" + ajaxInfo.list + "&action=get";
+            urlToGet = "http://"+website+"/forums/ajax_edit_message.php?id_message=" + QString::number(oldIdOfLastMessageOfUser) + "&" + ajaxInfo.list + "&action=get";
             requestForEditInfo = parsingToolClass::buildRequestWithThisUrl(urlToGet);
             oldAjaxInfo = ajaxInfo;
             ajaxInfo.list.clear();
@@ -427,7 +428,7 @@ void showTopicMessagesClass::getQuoteInfo(QString idOfMessageQuoted)
 
     if(ajaxInfo.list.isEmpty() == false && replyForQuoteInfo == nullptr)
     {
-        QNetworkRequest requestForQuoteInfo = parsingToolClass::buildRequestWithThisUrl("http://www.jeuxvideo.com/forums/ajax_citation.php");
+        QNetworkRequest requestForQuoteInfo = parsingToolClass::buildRequestWithThisUrl("http://"+website+"/forums/ajax_citation.php");
         QString dataForQuote = "id_message=" + idOfMessageQuoted + "&" + ajaxInfo.list;
         replyForQuoteInfo = timeoutForQuoteInfo.resetReply(networkManager->post(requestForQuoteInfo, dataForQuote.toLatin1()));
 
@@ -458,7 +459,7 @@ void showTopicMessagesClass::deleteMessage(QString idOfMessageDeleted)
 
     if(ajaxInfo.mod.isEmpty() == false && replyForDeleteInfo == nullptr)
     {
-        QNetworkRequest requestForDeleteInfo = parsingToolClass::buildRequestWithThisUrl("http://www.jeuxvideo.com/forums/modal_del_message.php?tab_message[]=" + idOfMessageDeleted + "&type=delete&" + ajaxInfo.mod);
+        QNetworkRequest requestForDeleteInfo = parsingToolClass::buildRequestWithThisUrl("http://"+website+"/forums/modal_del_message.php?tab_message[]=" + idOfMessageDeleted + "&type=delete&" + ajaxInfo.mod);
         replyForDeleteInfo = timeoutForDeleteInfo.resetReply(networkManager->get(requestForDeleteInfo));
 
         if(replyForDeleteInfo->isOpen() == true)

--- a/respawnIrc/showTopicMessages.hpp
+++ b/respawnIrc/showTopicMessages.hpp
@@ -105,6 +105,7 @@ private:
     QString numberOfConnectedAndMP;
     QString topicLinkFirstPage;
     QString topicLinkLastPage;
+    QString website;
     QString topicName;
     QString pseudoOfUser;
     ajaxInfoStruct ajaxInfo;


### PR DESCRIPTION
Support pour les forumJV qui pourrait être utile d'intégrer.

Codé et testé avec la version 2.6 car impossibilité de compiler la lib hunspell, je l'ai intégré avec la dernière version, ça devait fonctionner sans soucis.

Modifications effectués : 
- prise en charge du domaine "forumjv.com" qui implique certaines modification du code qui n'était compatible que pour le domaine "jeuxvideo.com", incluant le parsing des messages/liste de topics, ou les liens de posts, édition, et suppression de messages.

Ajouts effectués : 
- Bouton dans le menu "Se connecter" afin de choisir entre forumJV et JVC (ajout temporaire, à modifier également si possible)
